### PR TITLE
Have the jobs run even if there are no lockable resources required

### DIFF
--- a/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkins/plugins/lockableresources/queue/LockableResourcesQueueTaskDispatcher.java
@@ -49,6 +49,9 @@ public class LockableResourcesQueueTaskDispatcher extends QueueTaskDispatcher {
 		StratOSControllerAPI stratosAPI = LockableResourceStratos.getControllerAPI();
 		
 		RequiredResourcesProperty property = Utils.getProperty(project);
+		// If the project does not require any lockable resources then return null
+		if(property == null)
+			return null;
 		String name = property.getResourceNames();
 		
 		// If stratos is healthy but the resource is not a valid resource


### PR DESCRIPTION
Fix an issue where jobs would not run if there are no lockable resources required